### PR TITLE
날짜 계산기 추가

### DIFF
--- a/message.py
+++ b/message.py
@@ -411,17 +411,21 @@ def messageCalDay(cal, message):
     strMessage = ""
     day = datetime.datetime.now()
     try:
-        message = message.replace("!날짜더하기", "").replace("!날짜빼기", "").replace(" ", "").replace("일", "")
+        if "주" in message:
+            flag = 1
+        message = message.replace("!날짜더하기", "").replace("!날짜빼기", "").replace(" ", "").replace("일", "").replace("주", "")
         if message.isdigit() == False:
             raise
         if cal == 1:
+            if flag:
+                message = int(message) * 7
             dday = day + datetime.timedelta(days=int(message))
             strMessage = "오늘을 기준으로 %s일 후는 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
         elif cal == 0:
             dday = day - datetime.timedelta(days=int(message))
             strMessage = "오늘을 기준으로 %s일 전은 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
     except:
-        strMessage = "존재하지 않는 날짜이거나 사용 불가능한 형식입니다.\\mex) !날짜더하기 100일 or !날짜빼기 1000"
+        strMessage = "존재하지 않는 날짜이거나 사용 불가능한 형식입니다.\\mex) !날짜더하기 100일 or !날짜빼기 16주"
     return strMessage
 
 def messageChalsGraduate():

--- a/message.py
+++ b/message.py
@@ -409,21 +409,28 @@ def messageCAUMeal(mealTypeID):
 
 def messageCalDay(cal, message):
     strMessage = ""
+    weekly = 0
     day = datetime.datetime.now()
     try:
         if "주" in message:
-            flag = 1
+            weekly = 1
         message = message.replace("!날짜더하기", "").replace("!날짜빼기", "").replace(" ", "").replace("일", "").replace("주", "")
         if message.isdigit() == False:
             raise
         if cal == 1:
-            if flag:
-                message = int(message) * 7
-            dday = day + datetime.timedelta(days=int(message))
-            strMessage = "오늘을 기준으로 %s일 후는 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
+            if weekly == 1:
+                dday = day + datetime.timedelta(days=int(message) * 7)
+                strMessage = "오늘을 기준으로 %s주 후는 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
+            else:
+                dday = day + datetime.timedelta(days=int(message))
+                strMessage = "오늘을 기준으로 %s일 후는 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
         elif cal == 0:
-            dday = day - datetime.timedelta(days=int(message))
-            strMessage = "오늘을 기준으로 %s일 전은 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
+            if weekly == 1:
+                dday = day - datetime.timedelta(days=int(message) * 7)
+                strMessage = "오늘을 기준으로 %s주 전은 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
+            else:
+                dday = day - datetime.timedelta(days=int(message))
+                strMessage = "오늘을 기준으로 %s일 전은 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
     except:
         strMessage = "존재하지 않는 날짜이거나 사용 불가능한 형식입니다.\\mex) !날짜더하기 100일 or !날짜빼기 16주"
     return strMessage

--- a/message.py
+++ b/message.py
@@ -35,6 +35,11 @@ def getReplyMessage(message, room, sender):
         strResult = messageFakeNews(message)
     elif "!기억" in message:
         strResult = messageRemember(message, room)
+    elif "!날짜" in message:
+        if "더하기" in message:
+            strResult = messageCalDay(1, message)
+        elif "빼기" in message:
+            strResult = messageCalDay(0, message)
     elif "!메모" in message:
         strResult = messageMemo(message, sender)
     elif "아.." in message:
@@ -400,6 +405,23 @@ def messageCAUMeal(mealTypeID):
             strMenu = "정보가 없습니다."
         strMessage += f"\n{mealItem['rest']} : {strMenu}"
 
+    return strMessage
+
+def messageCalDay(cal, message):
+    strMessage = ""
+    day = datetime.datetime.now()
+    try:
+        message = message.replace("!날짜더하기", "").replace("!날짜빼기", "").replace(" ", "").replace("일", "")
+        if message.isdigit() == False:
+            raise
+        if cal == 1:
+            dday = day + datetime.timedelta(days=int(message))
+            strMessage = "오늘을 기준으로 %s일 후는 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
+        elif cal == 0:
+            dday = day - datetime.timedelta(days=int(message))
+            strMessage = "오늘을 기준으로 %s일 전은 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
+    except:
+        strMessage = "존재하지 않는 날짜이거나 사용 불가능한 형식입니다.\\mex) !날짜더하기 100일 or !날짜빼기 1000"
     return strMessage
 
 def messageChalsGraduate():


### PR DESCRIPTION
## Summary
- 현재 날짜를 기준으로 n일 혹은 n주 전/후의 날짜를 알려주는 기능을 구현했습니다.
- (활용 예로는 알뜰폰의 번이 날짜 등등..)

## Description
- 사용 가능한 형식은 다음과 같습니다.

  - !날짜더하기 100일
  - !날짜더하기 16주
  - !날짜빼기 1000일

- 키워드 감지 파트입니다. '!날짜' 키워드를 먼저 식별하고, 그 후에 '더하기'와 '빼기'를 식별합니다.
더하기의 경우 flag 값으로 1을, 빼기의 경우 0을 message와 함께 messageCalDay 함수로 보내줍니다.
```python
elif "!날짜" in message:
    if "더하기" in message:
        strResult = messageCalDay(1, message)
    elif "빼기" in message:
        strResult = messageCalDay(0, message)
``` 

- messageCalDay 함수의 초입 단계입니다.
strMessage와 weekly(이 함수가 주 단위로 계산해야 하는지 판별하는 flag 값) 그리고 day 값을 초기화 및 설정해줍니다.
- message에 '주' (ex. 16주)라는 단어가 있는지 확인하고, 만약 있다면 함수에게 일이 아닌 주 단위로 계산해야 한다고 알려주기 위해 weekly 값을 1로 설정해줍니다.
- message에 불필요한 단어들을 제거해준 뒤 .isdigit() 함수를 이용해서 숫자만 남았는지 확인해줍니다.
만약 숫자 외에 다른 문자가 남아서 False 값을 리턴했다면 사용자가 해당 함수의 양식을 지키지 않았다는 것이므로 raise합니다.
```python
def messageCalDay(cal, message):
    strMessage = ""
    weekly = 0
    day = datetime.datetime.now()
    try:
        if "주" in message:
            weekly = 1
        message = message.replace("!날짜더하기", "").replace("!날짜빼기", "").replace(" ", "").replace("일", "").replace("주", "")
        if message.isdigit() == False:
            raise
```

- 더하기 파트입니다.
날짜 차이는 timedelta 함수를 이용해서 구현했고, weekly가 1이면 주 단위로 계산되게, 아니라면 일 단위로 계산되게 코드를 작성했습니다.

```python
if cal == 1:
    if weekly == 1:
        dday = day + datetime.timedelta(days=int(message) * 7)
        strMessage = "오늘을 기준으로 %s주 후는 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
    else:
        dday = day + datetime.timedelta(days=int(message))
        strMessage = "오늘을 기준으로 %s일 후는 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
```

- 빼기 파트입니다.
전체적인 틀은 위와 동일하나, dday 변수에 timedelta값을 더하는 것이 아닌 빼는 것으로 코드를 구현했습니다.

```python
elif cal == 0:
    if weekly == 1:
        dday = day - datetime.timedelta(days=int(message) * 7)
        strMessage = "오늘을 기준으로 %s주 전은 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
    else:
        dday = day - datetime.timedelta(days=int(message))
        strMessage = "오늘을 기준으로 %s일 전은 %s년 %s월 %s일입니다." % (message, dday.year, dday.month, dday.day)
```

- 마지막은 모종의 이유로 함수에서 오류가 났거나, raise를 당하게 된 경우 except를 통해 오류 문구를 출력하고, strMessage를 return하는 것으로 함수를 종료합니다.

```python
except:
    strMessage = "존재하지 않는 날짜이거나 사용 불가능한 형식입니다.\\mex) !날짜더하기 100일 or !날짜빼기 16주"
return strMessage
```

- 간단한 작업 내용(커밋) 정리
  - Add Function; messageCalDay: messageCalDay 함수의 맨 첫 구현
  - Add function; enable weekly calculation: messageCalDay 함수가 '주' 단위도 처리할 수 있게 코드 개선
  - Fix err: 자질구레한 버그 해결

끝.