### PR TITLE
2가지 수정사항

### DIFF
--- a/message.py
+++ b/message.py
@@ -867,8 +867,10 @@ def messageNSULibrary():
     first = "제1 자유열람실 : 여석 %s석 (%s석 사용중)\n" % (Response['data']['data'][0]['available'], Response['data']['data'][0]['inUse'])
     second = "제2 자유열람실 : 여석 %s석 (%s석 사용중)\n" % (Response['data']['data'][1]['available'], Response['data']['data'][1]['inUse'])
     third = "제3 자유열람실 : 여석 %s석 (%s석 사용중)" % (Response['data']['data'][2]['available'], Response['data']['data'][1]['inUse'])
-        
+
     strMessage = "남서울대학교 열람실 좌석현황(성암기념중앙도서관)\n\n" + first + second + third
+    
+    return strMessage
 
 def messageNSUMeal(NSU_BAP, food_list):
     strMessage = ""

--- a/message.py
+++ b/message.py
@@ -42,6 +42,8 @@ def getReplyMessage(message, room, sender):
             strResult = messageCalDay(0, message)
     elif "!메모" in message:
         strResult = messageMemo(message, sender)
+    elif "마법의 소라고동이시여" in message:
+        strResult = messageSora(message)
     elif "아.." in message:
         strResult = messageAh()
     elif "안사요" in message or "안 사요" in message or "사지말까" in message or "사지 말까" in message or "안살래" in message or "안 살래" in message:
@@ -63,6 +65,8 @@ def getReplyMessage(message, room, sender):
             strResult = messageCAULibrary("2")
         elif "안성" in message:
             strResult = messageCAULibrary("3")
+        elif "남샤" in message:
+            strResult = messageNSULibrary()
         else:
             strResult = messageCAULibrary("")
     elif "학식" in message:
@@ -181,9 +185,6 @@ def getReplyMessage(message, room, sender):
         strResult = messageRemreturn(room)
     elif "뭐더라" in message:
         strResult = messageMemreturn(sender)
-    elif "마법의 소라고동이시여" in message:
-        strResult = messageSora(message)
-
 
     return strResult
 
@@ -856,6 +857,18 @@ def messageMM():
     strMessage = "정색하지 마세요;;"
 
     return strMessage
+
+def messageNSULibrary():
+    strMessage = ""
+    strUrl = "http://220.68.191.20/setting"
+    requestSession = requests.Session()
+    Response = requestSession.get(strUrl, headers={'Content-Type': 'application/x-www-form-urlencoded'}).json()
+    Response = dict(Response)
+    first = "제1 자유열람실 : 여석 %s석 (%s석 사용중)\n" % (Response['data']['data'][0]['available'], Response['data']['data'][0]['inUse'])
+    second = "제2 자유열람실 : 여석 %s석 (%s석 사용중)\n" % (Response['data']['data'][1]['available'], Response['data']['data'][1]['inUse'])
+    third = "제3 자유열람실 : 여석 %s석 (%s석 사용중)" % (Response['data']['data'][2]['available'], Response['data']['data'][1]['inUse'])
+        
+    strMessage = "남서울대학교 열람실 좌석현황(성암기념중앙도서관)\n\n" + first + second + third
 
 def messageNSUMeal(NSU_BAP, food_list):
     strMessage = ""


### PR DESCRIPTION
## Summary
- 마법의 소라고동 기능이 다른 키워드에 인터셉트당하는 것을 방지하기 위해 단어 인식 위치를 상단에 위치하게끔 조정
- 남서울대학교 열람실 파싱 기능 추가

## Description
- 아래와 같은 상황을 방지하기 위해서 소라고동의 단어 인식 위치를 조정했습니다.

![image](https://github.com/yymin1022/Wa_API/assets/10193967/bea0b82d-4cd4-4c31-bbc1-76316d38a235)

- 남서울대학교에 있는 세곳의 열람실에 대한 좌석 정보를 불러올 수 있는 기능을 추가했습니다.

```python
strMessage = ""
strUrl = "http://220.68.191.20/setting" # 열람실 좌석 관련한 정보가 들어있는 URL
requestSession = requests.Session()
Response = requestSession.get(strUrl, headers={'Content-Type': 'application/x-www-form-urlencoded'}).json()
Response = dict(Response) # Dictionary로 자료를 캐스팅
# Response['data']['data'][열람실 번호]['불러올 자료 (available, inUse)']
first = "제1 자유열람실 : 여석 %s석 (%s석 사용중)\n" % (Response['data']['data'][0]['available'], Response['data']['data'][0]['inUse'])
second = "제2 자유열람실 : 여석 %s석 (%s석 사용중)\n" % (Response['data']['data'][1]['available'], Response['data']['data'][1]['inUse'])
third = "제3 자유열람실 : 여석 %s석 (%s석 사용중)" % (Response['data']['data'][2]['available'], Response['data']['data'][1]['inUse'])

strMessage = "남서울대학교 열람실 좌석현황(성암기념중앙도서관)\n\n" + first + second + third

return strMessage
``` 
