### PR TITLE
원하는 표준 시간대의 시간을 출력하는 기능 추가

### DIFF
--- a/message.py
+++ b/message.py
@@ -71,6 +71,8 @@ def getReplyMessage(message, room, sender):
         strResult = messageCustomTracker(message)
     elif "마법의 소라고동이시여" in message:
         strResult = messageSora(message)
+    elif "!시간" in message:
+        strResult = messageFt_timezone(message)
     elif "아.." in message:
         strResult = messageAh()
     elif "안사요" in message or "안 사요" in message or "사지말까" in message or "사지 말까" in message or "안살래" in message or "안 살래" in message:
@@ -1345,6 +1347,23 @@ def messageSGW():
     elif randInt == 3:
         strMessage = "이미 차단당한 유저입니다."
     
+    return strMessage
+
+def messageFt_timezone(message):
+    strMessage = ""
+    try:
+        message = message.replace("!시간 ", "").replace(" ", "")
+        if message.startswith('+') or message.startswith('-'):
+            if int(message) > 12 or int(message) < -11:
+                raise
+            offset = datetime.timedelta(hours=int(message))
+        else:
+            hours, minutes = map(int, message.split(':'))
+            offset = datetime.timedelta(hours=hours, minutes=minutes)
+        adjusted_time = datetime.datetime.now(datetime.timezone.utc) + offset
+        strMessage = f"현재 UTC{message}의 시간은 ", adjusted_time.strftime('%Y-%m-%d %H:%M:%S') , "입니다."
+    except:
+        strMessage = "사용 형식이 잘못됐거나 존재하지 않는 시간대입니다.\\m사용법: !시간 +9 or !시간 -11"
     return strMessage
 
 def messageUh():

--- a/message.py
+++ b/message.py
@@ -72,7 +72,7 @@ def getReplyMessage(message, room, sender):
     elif "마법의 소라고동이시여" in message:
         strResult = messageSora(message)
     elif "!시간" in message:
-        strResult = messageFt_timezone(message)
+        strResult = messageTimezone(message)
     elif "아.." in message:
         strResult = messageAh()
     elif "안사요" in message or "안 사요" in message or "사지말까" in message or "사지 말까" in message or "안살래" in message or "안 살래" in message:
@@ -1349,7 +1349,7 @@ def messageSGW():
     
     return strMessage
 
-def messageFt_timezone(message):
+def messageTimezone(message):
     strMessage = ""
     try:
         message = message.replace("!시간 ", "").replace(" ", "")


### PR DESCRIPTION
## Summary
- tjo가 파리에 놀러간 기념으로 슥슥 짜봤습니다.

## Description
- "!시간 [원하는 시간대]" 명령어를 통해 시간을 출력할 수 있습니다.
실행 결과는 다음과 같습니다.
```
root@52c068ba1e72:~/misc# python test.py
시간대> +9
현재 UTC+9의 시간은  2023-11-06 13:31:54 입니다.
root@52c068ba1e72:~/misc# python test.py
시간대> -11
현재 UTC-11의 시간은  2023-11-05 17:32:02 입니다.
root@52c068ba1e72:~/misc# python test.py
시간대> +13 // 표준 시간대가 -11부터 +12까지 존재하므로 이 범위 외의 값이 들어오면 raise합니다.
Traceback (most recent call last):
  File "test.py", line 5, in <module>
    raise
RuntimeError: No active exception to reraise
root@52c068ba1e72:~/misc#
``` 