### PR TITLE
택배, 통관 기능 수정

### DIFF
--- a/message.py
+++ b/message.py
@@ -99,7 +99,7 @@ def getReplyMessage(message, room, sender):
     elif "!메모" in message:
         strResult = messageMemo(message, sender)
     elif "!택배" in message or "!ㅌㅂ" in message:
-        strResult = messageLogisticsParser(message)
+        strResult = messageLogistics(message)
     elif "!통관" in message or "!ㅌㄱ" in message:
         strResult = messageCustomTracker(message)
     elif "!촙촙" in message:
@@ -765,13 +765,27 @@ def messageLaugh():
     messages = ["뭘 웃어요;;", "안웃긴데;;", "이게 웃겨요?"]
     return random.choice(messages)
 
-def messageLogisticsParser(message):
+def messageLogistics(message):
     strMessage = ""
     message = message.replace("!택배", "").replace("!ㅌㅂ", "").replace(" ", "")
+
     if message == "":
-        strMessage = "///택배 운송장조회 사용 방법///\\m사용 예시: !택배[운송장번호]\nex)!택배1234567890\n지원중인 택배사: 우체국택배, 대한통운(CJ, 대통), 로젠택배, 롯데택배, 한진택배"
+        strMessage = "///택배 운송장조회 사용 방법///\\m사용 예시: !택배[운송장번호]\nex)!택배1234567890\n지원중인 택배사: 우체국택배, 대한통운(CJ, 대통), 로젠택배, 롯데택배, 한진택배\n만약 통관 중인 택배라면 우선적으로 통관 상황을 조회합니다."
         return strMessage
 
+    strMessage = messageCustomTracker(message)
+    if "존재하지 않는 운송장" in strMessage:
+        strMessage = messageLogisticsParser(message)
+    else:
+        tmpmsg = messageLogisticsParser(message)
+        if "존재하지 않는 운송장" in tmpmsg:
+            strMessage =  strMessage + "\\m현재 택배사에 인계되지 않은 화물입니다."
+        else:
+            strMessage = strMessage + "\\m" + tmpmsg
+
+    return strMessage
+
+def messageLogisticsParser(message):
     logistics = [
         messageLogisticsParser_CJ,
         messageLogisticsParser_HJ,
@@ -784,7 +798,7 @@ def messageLogisticsParser(message):
         strMessage = parser(message)
         if strMessage: return strMessage
 
-    strMessage = "미집하된 화물이거나 존재하지 않는 운송장 번호입니다.\\m사용 예시: !택배[운송장번호]\nex)!택배1234567890\n지원중인 택배사: 우체국택배, 대한통운(CJ, 대통), 로젠택배, 롯데택배, 한진택배"
+    strMessage = "미집하된 택배이거나 존재하지 않는 운송장 번호입니다.\\m사용 예시: !택배[운송장번호]\nex)!택배1234567890\n지원중인 택배사: 우체국택배, 대한통운(CJ, 대통), 로젠택배, 롯데택배, 한진택배"
 
     return strMessage
 

--- a/message.py
+++ b/message.py
@@ -98,9 +98,9 @@ def getReplyMessage(message, room, sender):
             strResult = messageCalDay(0, message)
     elif "!메모" in message:
         strResult = messageMemo(message, sender)
-    elif "!택배" in message:
+    elif "!택배" in message or "!ㅌㅂ" in message:
         strResult = messageLogisticsParser(message)
-    elif "!통관" in message:
+    elif "!통관" in message or "!ㅌㄱ" in message:
         strResult = messageCustomTracker(message)
     elif "!촙촙" in message:
         strResult = messageChopchop(message)
@@ -553,7 +553,7 @@ def messageCry():
 def messageCustomTracker(message):
     strMessage = ""
     try:
-        message = message.replace('!통관', '').replace(" ", "")
+        message = message.replace('!통관', '').replace('!ㅌㄱ', '').replace(" ", "")
         key = os.environ['CUSTOM_API_KEY']
         year = datetime.date.today().year
         url = 'https://unipass.customs.go.kr:38010/ext/rest/cargCsclPrgsInfoQry/retrieveCargCsclPrgsInfo?crkyCn=%s&blYy=%s&hblNo=%s' % (key, year, message)
@@ -767,7 +767,7 @@ def messageLaugh():
 
 def messageLogisticsParser(message):
     strMessage = ""
-    message = message.replace("!택배", "").replace(" ", "")
+    message = message.replace("!택배", "").replace("!ㅌㅂ", "").replace(" ", "")
     if message == "":
         strMessage = "///택배 운송장조회 사용 방법///\\m사용 예시: !택배[운송장번호]\nex)!택배1234567890\n지원중인 택배사: 우체국택배, 대한통운(CJ, 대통), 로젠택배, 롯데택배, 한진택배"
         return strMessage

--- a/message.py
+++ b/message.py
@@ -886,6 +886,7 @@ def messageLogisticsParser_KP(message):
         infom = temp.split('\n')
         for _ in range(len(infom)):
             if '\t' in infom[_]: infom[_] = infom[_].replace('\t', '')
+        if infom[5] == '': infom[5] = '접수'
         if infom[5] == '            ': infom[5] = '배달준비'
         strMessage = "/// 우체국택배 배송조회 ///\n\n날짜: %s\n시간: %s\n발생국: %s\n처리현황: %s" % (infom[1], infom[2], infom[3], infom[5])
     except:


### PR DESCRIPTION
## Summary
- 택배와 통관의 기능을 수정했습니다.

## Description
- !ㅌㅂ, !ㅌㄱ 처럼 초성으로만 입력해도 작동하게끔 코드를 수정했습니다.
- 우체국택배에서 맨 첫 단계 (접수, 인수완료, 수거완료 등등)에서 문자열이 제대로 출력되지 않던 문제를 야매로 해결했습니다.
  - ~근데 실제로 테스트 할 송장번호가 없어서 제대로 작동할진 모르겠습니다 아마 되겠죠 머~
- 택배 조회 기능에서 자동으로 통관 현황도 조회하게끔 코드를 수정했습니다.
  - 만약 통관 조회에 실패하면 이전과 같이 택배 조회로 넘어갑니다.
  - 통관 조회에 성공했다면 통관 정보에 추가로 택배 조회를 진행합니다.
  - 혹시 통관 조회만 진행하려는 사람이 있을까 해서 '!통관' 키워드 자체는 삭제하지 않고 남겨뒀습니다.
  
![image](https://github.com/user-attachments/assets/6586d64f-a155-4a24-accd-b90c14b13e8a)
