### PR TITLE
[DEV] 택배/통관 조회 기능 개선

### DIFF
--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -191,34 +191,32 @@ def message_logistics_parser_koreapost(message) -> str | None:
         return None
 
 def message_logistics_parser_logen(message) -> str | None:
-    i = 1
-    temp = ""
     try:
-        if not message.isdigit():
-            raise TypeError
-        logistics_url =  logistics_urls["Logen"] % (message)
+        logistics_url = logistics_urls["Logen"] % (message)
         request_session = requests.Session()
-        request_response = request_session.get(logistics_url, headers = request_headers, verify=certifi.where())
+        request_response = request_session.get(logistics_url, headers=request_headers, verify=certifi.where())
         soup = BeautifulSoup(request_response.text, "html.parser")
-        while True:
-            info = soup.select("body > div.contents.personal.tkSearch > section > div > div.tab_container > div > table.data.tkInfo > tbody > tr:nth-child(%d)" % i)
-            if not info:
-                info = soup.select("body > div.contents.personal.tkSearch > section > div > div.tab_container > div > table.data.tkInfo > tbody > tr:nth-child(%d)" % int(i-1))
-                for tag in info:
-                    temp += tag.get_text()
-                break
-            i = i+1
-        infom = temp.split("\n")
-        for _ in range(len(infom)):
-            if "\t" in infom[_]: infom[_] = infom[_].replace("\t", "")
-        infom = [v for v in infom if v]
+
+        rows = soup.select("body > div.contents.personal.tkSearch > section > div > div.tab_container > div > table.data.tkInfo > tbody > tr")
+        if not rows:
+            return None
+            
+        temp_text = rows[-1].get_text()
+        infom = [line.replace("\t", "") for line in temp_text.split("\n") if line.replace("\t", "")]
+
+        if len(infom) < 4:
+            return None
+
         temp = ""
-        if "전달" in infom[3]:
-            temp = "\n인수자: " + infom[5]
-        elif "배달 준비" in infom[3]:
-            temp = "\n배달 예정 시간: " + infom[5]
-        return f"/// 로젠택배 배송조회 ///\n\n날짜: {infom[0]}\n사업장: {infom[1]}\n배송상태: {infom[2]}\n배송내용: {infom[3]}" + temp
-    except (TypeError, IndexError):
+        if len(infom) > 5:
+            if "전달" in infom[3]:
+                temp = f"\n인수자: {infom[5]}"
+            elif "배달 준비" in infom[3]:
+                temp = f"\n배달 예정 시간: {infom[5]}"
+
+        return f"/// 로젠택배 배송조회 ///\n\n날짜: {infom[0]}\n사업장: {infom[1]}\n배송상태: {infom[2]}\n배송내용: {infom[3]}{temp}"
+
+    except (TypeError, ValueError, IndexError, AttributeError):
         return None
 
 def message_logistics_parser_lotte(message) -> str | None:

--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -76,15 +76,16 @@ def message_logistics_parser(message) -> str | None:
             if str_message: return str_message
     except Exception as e:
         print(f"General exception occured in message_logistics_parser..: {e}")
+        return "운송장 조회 중 오류가 발생했습니다.\n잠시 후 다시 시도해주세요."
 
     return None
 
-def message_logistics_parser_cj(message):
+def message_logistics_parser_cj(message) -> str | None:
     try:
         post_data = {"wblNo": message}
         logistics_url_info = logistics_urls["CJ"]
         request_response = requests.post(logistics_url_info, headers=request_headers, data=post_data)
-        if request_response.status_code != 200 or not request_response.json().get("data"): return ""
+        if request_response.status_code != 200 or not request_response.json().get("data"): return None
         tracking_data = request_response.json()["data"]
         sndr_nm = (tracking_data.get("sndrNm") or "").strip() or "(정보 없음)"
         rcvr_nm = (tracking_data.get("rcvrNm") or "").strip() or "(정보 없음)"
@@ -118,9 +119,9 @@ def message_logistics_parser_cj(message):
             f"{status_info}"
         )
     except (TypeError, IndexError):
-        return ""
+        return None
 
-def message_logistics_parser_hanjin(message):
+def message_logistics_parser_hanjin(message) -> str | None:
     i = 1
     temp = ""
     try:
@@ -145,9 +146,9 @@ def message_logistics_parser_hanjin(message):
         goods_name = goods_name[0].get_text().strip()
         return f"/// 한진택배 배송조회 ///\n\n상품명: {goods_name}\n날짜: {infom[1]}\n시간: {infom[2]}\n상품위치: {infom[3]}\n배송 진행상황: {infom[5]}\n전화번호: {infom[7]}"
     except (TypeError, IndexError):
-        return ""
+        return None
 
-def message_logistics_parser_koreapost(message):
+def message_logistics_parser_koreapost(message) -> str | None:
     i = 1
     temp = ""
     try:
@@ -171,9 +172,9 @@ def message_logistics_parser_koreapost(message):
         if infom[5] == "            ": infom[5] = "배달준비"
         return f"/// 우체국택배 배송조회 ///\n\n날짜: {infom[1]}\n시간: {infom[2]}\n발생국: {infom[3]}\n처리현황: {infom[5]}"
     except (TypeError, IndexError):
-        return ""
+        return None
 
-def message_logistics_parser_logen(message):
+def message_logistics_parser_logen(message) -> str | None:
     i = 1
     temp = ""
     try:
@@ -202,9 +203,9 @@ def message_logistics_parser_logen(message):
             temp = "\n배달 예정 시간: " + infom[5]
         return f"/// 로젠택배 배송조회 ///\n\n날짜: {infom[0]}\n사업장: {infom[1]}\n배송상태: {infom[2]}\n배송내용: {infom[3]}" + temp
     except (TypeError, IndexError):
-        return ""
+        return None
 
-def message_logistics_parser_lotte(message):
+def message_logistics_parser_lotte(message) -> str | None:
     temp = ""
     try:
         if not message.isdigit():
@@ -223,4 +224,4 @@ def message_logistics_parser_lotte(message):
         infom[6] = infom[6][:10] + " " + infom[6][10:]
         return f"/// 롯데택배 배송조회 ///\n\n단계: {infom[5]}\n시간: {infom[6]}\n현위치: {infom[7]}\n처리현황: {infom[8]}"
     except (TypeError, IndexError):
-        return ""
+        return None

--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -64,18 +64,29 @@ def message_logistics_main(message) -> str:
     return str_message
 
 def message_logistics_parser(message) -> str | None:
-    logistics = [message_logistics_parser_cj,
-                message_logistics_parser_hanjin,
-                message_logistics_parser_koreapost,
-                message_logistics_parser_logen,
-                message_logistics_parser_lotte]
+    logistics = [
+        message_logistics_parser_cj,
+        message_logistics_parser_hanjin,
+        message_logistics_parser_koreapost,
+        message_logistics_parser_logen,
+        message_logistics_parser_lotte,
+    ]
 
-    try:
-        for parser in logistics:
-            str_message = parser(message)
-            if str_message: return str_message
-    except Exception as e:
-        print(f"General exception occured in message_logistics_parser..: {e}")
+    had_exception = False
+
+    for parser in logistics:
+        try:
+            result = parser(message)
+            if result:
+                return result
+        except Exception as e:
+            had_exception = True
+            print(
+                f"[message_logistics_parser] Unexpected exception in "
+                f"{parser.__name__!r} ({type(e).__name__}): {e}"
+            )
+
+    if had_exception: # 5개의 택배사 모두 조회에 실패한 상태에서 오류가 발생한 경우
         return "운송장 조회 중 오류가 발생했습니다.\n잠시 후 다시 시도해주세요."
 
     return None
@@ -83,19 +94,20 @@ def message_logistics_parser(message) -> str | None:
 def message_logistics_parser_cj(message) -> str | None:
     try:
         post_data = {"wblNo": message}
-        logistics_url_info = logistics_urls["CJ"]
+        logistics_url_info = logistics_urls["CJ"] # 운송장 기본 정보 조회 (받는사람, 보내는사람, 상품명 등)
         request_response = requests.post(logistics_url_info, headers=request_headers, data=post_data)
         if request_response.status_code != 200 or not request_response.json().get("data"): return None
         tracking_data = request_response.json()["data"]
-        sndr_nm = (tracking_data.get("sndrNm") or "").strip() or "(정보 없음)"
-        rcvr_nm = (tracking_data.get("rcvrNm") or "").strip() or "(정보 없음)"
-        goods_nm = (tracking_data.get("repGoodsNm") or "").strip() or "(정보 없음)"
-        qty = (tracking_data.get("qty") or "").strip() or "(정보 없음)"
-        acpr_nm = (tracking_data.get("acprNm") or "").strip() or "(정보 없음)"
+        sndr_nm = (tracking_data.get("sndrNm") or "").strip() or "(정보 없음)"      # 보낸 사람 이름
+        rcvr_nm = (tracking_data.get("rcvrNm") or "").strip() or "(정보 없음)"      # 받는 사람 이름
+        goods_nm = (tracking_data.get("repGoodsNm") or "").strip() or "(정보 없음)" # 상품명
+        qty = (tracking_data.get("qty") or "").strip() or "(정보 없음)"             # 수량
+        acpr_nm = (tracking_data.get("acprNm") or "").strip() or "(정보 없음)"      # 인수자
         
-        logistics_url_status = logistics_urls["CJ_status"]
+        logistics_url_status = logistics_urls["CJ_status"] # 운송장 배송 정보 조회 (배송상태, 처리장소 등)
         request_response = requests.post(logistics_url_status, headers=request_headers, data=post_data)
         status_info = "현재 집하되지 않은 택배입니다."
+
         if (request_response.status_code == 200 and
             request_response.json().get("data") and
             request_response.json()["data"].get("svcOutList")):
@@ -110,6 +122,7 @@ def message_logistics_parser_cj(message) -> str | None:
                 f"{'인수자' if '인수자' in ((latest_status.get('patnBranNm') or '').strip() or '(정보 없음)') else '상대장소'}: "
                 f"{(latest_status.get('patnBranNm') or '').strip() or '(정보 없음)'}"
             )
+            
         return (
             f"/// CJ대한통운 배송조회 ///\n\n"
             f"송화인: {sndr_nm}\n"

--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -70,9 +70,12 @@ def message_logistics_parser(message) -> str | None:
                 message_logistics_parser_logen,
                 message_logistics_parser_lotte]
 
-    for parser in logistics:
-        str_message = parser(message)
-        if str_message: return str_message
+    try:
+        for parser in logistics:
+            str_message = parser(message)
+            if str_message: return str_message
+    except Exception as e:
+        print(f"General exception occured in message_logistics_parser..: {e}")
 
     return None
 

--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -18,13 +18,13 @@ request_headers = {
 }
 
 logistics_urls = {
-    "Customs": "https://unipass.customs.go.kr:38010/ext/rest/cargCsclPrgsInfoQry/retrieveCargCsclPrgsInfo?crkyCn=%s&blYy=%s&hblNo=%s", # 통관
-    "CJ": "https://trace.cjlogistics.com/next/rest/selectTrackingWaybil.do",                                                           # 대한통운 기본 운송장 정보 조회
-    "CJ_status": "https://trace.cjlogistics.com/next/rest/selectTrackingDetailList.do",                                                # 대한통운 배송 정보 상세 조회                       
-    "Hanjin": "https://www.hanjin.com/kor/CMS/DeliveryMgr/WaybillResult.do?mCode=MN038&wblnum=%s&schLang=KR",                          # 한진택배
-    "KoreaPost": "https://service.epost.go.kr/trace.RetrieveDomRigiTraceList.comm?sid1=%s",                                            # 우체국택배
-    "Logen": "https://www.ilogen.com/web/personal/trace/%s",                                                                           # 로젠택배
-    "Lotte": "https://www.lotteglogis.com/mobile/reservation/tracking/linkView?InvNo=%s"                                               # 롯데택배
+    "Customs":      "https://unipass.customs.go.kr:38010/ext/rest/cargCsclPrgsInfoQry/retrieveCargCsclPrgsInfo?crkyCn=%s&blYy=%s&hblNo=%s", # 통관
+    "CJ":           "https://trace.cjlogistics.com/next/rest/selectTrackingWaybil.do",                                                      # 대한통운 기본 운송장 정보 조회
+    "CJ_status":    "https://trace.cjlogistics.com/next/rest/selectTrackingDetailList.do",                                                  # 대한통운 배송 정보 상세 조회                       
+    "Hanjin":       "https://www.hanjin.com/kor/CMS/DeliveryMgr/WaybillResult.do?mCode=MN038&wblnum=%s&schLang=KR",                         # 한진택배
+    "KoreaPost":    "https://service.epost.go.kr/trace.RetrieveDomRigiTraceList.comm?sid1=%s",                                              # 우체국택배
+    "Logen":        "https://www.ilogen.com/web/personal/trace/%s",                                                                         # 로젠택배
+    "Lotte":        "https://www.lotteglogis.com/mobile/reservation/tracking/linkView?InvNo=%s"                                             # 롯데택배
 }
 
 def message_logistics(message, room, sender):
@@ -54,17 +54,12 @@ def message_logistics_main(message):
     message = message.replace("!택배", "").replace("!ㅌㅂ", "").replace(" ", "")
 
     if message == "":
-        return "///택배 운송장조회 사용 방법///\\m사용 예시: !택배[운송장번호]\nex)!택배1234567890\n지원중인 택배사: 우체국택배, 대한통운(CJ, 대통), 로젠택배, 롯데택배, 한진택배\n만약 통관 중인 택배라면 우선적으로 통관 상황을 조회합니다."
+        return "///택배 운송장조회 사용 방법///\\m사용 예시: !택배[운송장번호]\nex)!택배1234567890\n지원중인 택배사: 우체국택배, 대한통운(CJ, 대통), 로젠택배, 롯데택배, 한진택배"
 
-    str_message = message_custom_tracker(message)
+    str_message = message_logistics_parser(message)
+
     if "존재하지 않는 운송장" in str_message:
-        str_message = message_logistics_parser(message)
-    else:
-        tmp_message = message_logistics_parser(message)
-        if "존재하지 않는 운송장" in tmp_message:
-            str_message = f"{str_message}\\m현재 택배사에 인계되지 않은 화물입니다."
-        else:
-            str_message = f"{str_message}\\m{tmp_message}"
+        str_message = "현재 택배사에 인계되지 않은 화물입니다."
 
     return str_message
 

--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -166,29 +166,28 @@ def message_logistics_parser_hanjin(message) -> str | None:
         return None
 
 def message_logistics_parser_koreapost(message) -> str | None:
-    i = 1
-    temp = ""
     try:
-        if not message.isdigit(): raise TypeError
         logistics_url = logistics_urls["KoreaPost"] % (message)
         request_session = requests.Session()
-        request_response = request_session.get(logistics_url, headers = request_headers, verify=certifi.where())
+        request_response = request_session.get(logistics_url, headers=request_headers, verify=certifi.where())
         soup = BeautifulSoup(request_response.text, "html.parser")
-        while True:
-            info = soup.select("#processTable > tbody > tr:nth-child(%d)" % i)
-            if not info:
-                info = soup.select("#processTable > tbody > tr:nth-child(%d)" % int(i-1))
-                for tag in info:
-                    temp += tag.get_text()
-                break
-            i = i+1
-        infom = temp.split("\n")
-        for _ in range(len(infom)):
-            if "\t" in infom[_]: infom[_] = infom[_].replace("\t", "")
-        if infom[5] == "": infom[5] = "접수"
-        if infom[5] == "            ": infom[5] = "배달준비"
+
+        rows = soup.select("#processTable > tbody > tr")
+        if not rows:
+            return None
+            
+        temp = rows[-1].get_text()
+        infom = [line.replace("\t", "") for line in temp.split("\n")]
+
+        if len(infom) > 5: # TODO: 접수 혹은 수거 상태의 운송장번호를 입수하면 그때 정확한 데이터를 보고 올바르게 파싱하게 해야 됨
+            if infom[5] == "": 
+                infom[5] = "접수"
+            elif infom[5] == "            ":
+                infom[5] = "배달준비"
+
         return f"/// 우체국택배 배송조회 ///\n\n날짜: {infom[1]}\n시간: {infom[2]}\n발생국: {infom[3]}\n처리현황: {infom[5]}"
-    except (TypeError, IndexError):
+
+    except (TypeError, ValueError, IndexError, AttributeError):
         return None
 
 def message_logistics_parser_logen(message) -> str | None:

--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -2,6 +2,7 @@ from bs4 import BeautifulSoup
 
 import datetime
 import os
+import time
 
 import certifi
 import dotenv
@@ -81,18 +82,24 @@ def message_logistics_parser(message) -> str | None:
     had_exception = False
 
     for parser in logistics:
-        try:
-            result = parser(message)
-            if result:
-                return result
-        except Exception as e:
-            had_exception = True
-            print(
-                f"[message_logistics_parser] Unexpected exception in "
-                f"{parser.__name__!r} ({type(e).__name__}): {e}"
-            )
+        for attempt in range(3): # 오류 발생 시 3회까지 재시도
+            try:
+                result = parser(message)
+                if result: return result
+                break
+            except Exception as e:
+                if attempt < 2:
+                    time.sleep(1)
+                    continue
+                had_exception = True
+                print(
+                    f"[message_logistics_parser] Unexpected exception in "
+                    f"{parser.__name__!r} (Attempt {attempt + 1}) ({type(e).__name__}): {e}"
+                )
+                break
 
-    if had_exception: # 5개의 택배사 모두 조회에 실패한 상태에서 오류가 발생한 경우
+    # 5개의 택배사 모두 조회에 실패한 상태에서 작업에 오류가 발생한 기록이 있는 경우
+    if had_exception:
         return "운송장 조회 중 오류가 발생했습니다.\n잠시 후 다시 시도해주세요."
 
     return None

--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -51,15 +51,21 @@ def message_custom_tracker(message) -> str:
         return "존재하지 않는 운송장번호이거나 잘못된 형식 혹은 아직 입항하지 않은 화물입니다.\\m사용법: !통관 123456789"
 
 def message_logistics_main(message) -> str:
+    common_message = [
+        "///택배 운송장조회 사용 방법///\\m사용 예시: !택배[운송장번호]\nex)!택배1234567890\n지원중인 택배사: 우체국택배, 대한통운(CJ, 대통), 로젠택배, 롯데택배, 한진택배",
+        "존재하지 않는 운송장번호이거나 잘못된 형식 혹은 아직 수거되지 않은 화물입니다.\\m사용법: !택배[운송장번호]\nex)!택배1234567890\n지원중인 택배사: 우체국택배, 대한통운(CJ, 대통), 로젠택배, 롯데택배, 한진택배"
+    ]
     message = message.replace("!택배", "").replace("!ㅌㅂ", "").replace(" ", "")
 
     if message == "":
-        return "///택배 운송장조회 사용 방법///\\m사용 예시: !택배[운송장번호]\nex)!택배1234567890\n지원중인 택배사: 우체국택배, 대한통운(CJ, 대통), 로젠택배, 롯데택배, 한진택배"
+        return common_message[0]
+    elif not message.isdigit():
+        return common_message[1]
 
     str_message = message_logistics_parser(message)
 
     if not str_message:
-        return "존재하지 않는 운송장번호이거나 잘못된 형식 혹은 아직 수거되지 않은 화물입니다.\\m사용법: !택배[운송장번호]\nex)!택배1234567890\n지원중인 택배사: 우체국택배, 대한통운(CJ, 대통), 로젠택배, 롯데택배, 한진택배"
+        return common_message[1]
 
     return str_message
 
@@ -143,6 +149,7 @@ def message_logistics_parser_hanjin(message) -> str | None:
         request_session = requests.Session()
         request_response = request_session.get(logistics_url, headers = request_headers, verify=certifi.where())
         soup = BeautifulSoup(request_response.text, "html.parser")
+
         while True:
             info = soup.select("#delivery-wr > div > div.waybill-tbl > table > tbody > tr:nth-child(%d)" % i)
             if not info:
@@ -151,6 +158,7 @@ def message_logistics_parser_hanjin(message) -> str | None:
                     temp += tag.get_text()
                 break
             i = i+1
+
         infom = temp.split("\n")
         for _ in range(len(infom)):
             if infom[7] == "":

--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -11,10 +11,10 @@ import requests
 dotenv.load_dotenv()
 
 request_headers = {
-    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                    "AppleWebKit/537.36 (KHTML, like Gecko) "
-                    "Chrome/71.0.3578.98 Safari/537.36",
-    "Content-Type": "application/x-www-form-urlencoded"
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+    "Accept-Language": "ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7",
+    "Connection": "keep-alive"
 }
 
 logistics_urls = {

--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -38,16 +38,20 @@ def message_logistics(message, room, sender):
 def message_custom_tracker(message) -> str:
     try:
         message = message.replace("!통관", "").replace("!ㅌㄱ", "").replace(" ", "")
+
         key = os.environ["CUSTOM_API_KEY"]
         year = datetime.date.today().year
-        url = logistics_urls["Customs"] % (key, year, message)
-        result = requests.get(url)
+        result = requests.get(logistics_urls["Customs"] % (key, year, message)) # 통관 조회에선 message가 isdigit인지 검사하지 않음
+
         soup = BeautifulSoup(result.text, "xml")
-        name = soup.find("prnm")
-        customs_name = soup.find("etprCstm")
-        status = soup.find("prgsStts")
-        process_time = datetime.datetime.strptime(str(soup.find("prcsDttm").text), "%Y%m%d%H%M%S").strftime("%Y.%m.%d %H:%M:%S")
+        name = soup.find("prnm")                # 품명
+        customs_name = soup.find("etprCstm")    # 입항세관
+        status = soup.find("prgsStts")          # 통관진행상태
+        process_time = datetime.datetime.strptime(str(soup.find("prcsDttm").text), # 처리일시
+                                                  "%Y%m%d%H%M%S").strftime("%Y.%m.%d %H:%M:%S")
+
         return f"/// 관세청 UNIPASS 통관 조회 ///\n\n품명: {name.text}\n입항세관: {customs_name.text}\n통관진행상태: {status.text}\n처리일시: {process_time}"
+    
     except (TypeError, AttributeError):
         return "존재하지 않는 운송장번호이거나 잘못된 형식 혹은 아직 입항하지 않은 화물입니다.\\m사용법: !통관 123456789"
 
@@ -110,6 +114,7 @@ def message_logistics_parser_cj(message) -> str | None:
         logistics_url_info = logistics_urls["CJ"] # 운송장 기본 정보 조회 (받는사람, 보내는사람, 상품명 등)
         request_response = requests.post(logistics_url_info, headers=request_headers, data=post_data)
         if request_response.status_code != 200 or not request_response.json().get("data"): return None
+
         tracking_data = request_response.json()["data"]
         sndr_nm = (tracking_data.get("sndrNm") or "").strip() or "(정보 없음)"      # 보낸 사람 이름
         rcvr_nm = (tracking_data.get("rcvrNm") or "").strip() or "(정보 없음)"      # 받는 사람 이름
@@ -160,12 +165,23 @@ def message_logistics_parser_hanjin(message) -> str | None:
             temp = info[-1].get_text()
         
         infom = temp.split("\n")
+
+        """
+        infom[0] = 운송장번호
+        infom[1] = 날짜
+        infom[2] = 시간
+        infom[3] = 상품위치
+        infom[4] = 배송 진행상황
+        infom[5] = 배송 진행상황 상세
+        infom[6] = 인수자
+        infom[7] = 전화번호
+        """
         
         if len(infom) > 7 and not infom[7]:
             infom[7] = "(정보 없음)"
 
-        goods_name = soup.select_one("#delivery-wr > div > table > tbody > tr > td:nth-child(1)")
-        goods_name = goods_name.get_text().strip() if goods_name else ""
+        goods_name_raw = soup.select_one("#delivery-wr > div > table > tbody > tr > td:nth-child(1)")
+        goods_name = goods_name_raw.get_text().strip() if goods_name_raw else ""
 
         return f"/// 한진택배 배송조회 ///\n\n상품명: {goods_name}\n날짜: {infom[1]}\n시간: {infom[2]}\n상품위치: {infom[3]}\n배송 진행상황: {infom[5]}\n전화번호: {infom[7]}"
 
@@ -185,6 +201,15 @@ def message_logistics_parser_koreapost(message) -> str | None:
             
         temp = rows[-1].get_text()
         infom = [line.replace("\t", "") for line in temp.split("\n")]
+
+        """
+        infom[0] = 운송장번호
+        infom[1] = 날짜
+        infom[2] = 시간
+        infom[3] = 발생국
+        infom[4] = 처리장소
+        infom[5] = 처리현황
+        """
 
         if len(infom) > 5: # TODO: 접수 혹은 수거 상태의 운송장번호를 입수하면 그때 정확한 데이터를 보고 올바르게 파싱하게 해야 됨
             if infom[5] == "": 
@@ -210,6 +235,15 @@ def message_logistics_parser_logen(message) -> str | None:
             
         temp_text = rows[-1].get_text()
         infom = [line.replace("\t", "") for line in temp_text.split("\n") if line.replace("\t", "")]
+
+        """
+        infom[0] = 날짜
+        infom[1] = 사업장
+        infom[2] = 배송상태
+        infom[3] = 배송내용
+        infom[4] = 처리장소
+        infom[5] = 인수자 혹은 배달 예정 시간
+        """
 
         if len(infom) < 4:
             return None
@@ -241,6 +275,14 @@ def message_logistics_parser_lotte(message) -> str | None:
         remove_chars = str.maketrans("", "", "\t\r \xa0")
         infom = [line.translate(remove_chars) for line in temp.split("\n")]
         infom = [v for v in infom if v]
+
+        """
+        infom[0~4] = 테이블 헤더 (날짜, 시간, 단계, 현위치, 처리현황 등)
+        infom[5] = 단계
+        infom[6] = 시간 (날짜 포함)
+        infom[7] = 현위치
+        infom[8] = 처리현황
+        """
         
         if len(infom) < 9:
             return None

--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -59,7 +59,7 @@ def message_logistics_main(message) -> str:
 
     if message == "":
         return common_message[0]
-    elif not message.isdigit():
+    elif not message.isdigit(): # 추후 EMS 등 알파벳이 섞이는 서비스도 조회할거면 비활성화 필요함
         return common_message[1]
 
     str_message = message_logistics_parser(message)
@@ -141,32 +141,28 @@ def message_logistics_parser_cj(message) -> str | None:
         return None
 
 def message_logistics_parser_hanjin(message) -> str | None:
-    i = 1
     temp = ""
     try:
-        if not message.isdigit(): raise TypeError
         logistics_url = logistics_urls["Hanjin"] % (message)
         request_session = requests.Session()
-        request_response = request_session.get(logistics_url, headers = request_headers, verify=certifi.where())
+        request_response = request_session.get(logistics_url, headers=request_headers, verify=certifi.where())
         soup = BeautifulSoup(request_response.text, "html.parser")
 
-        while True:
-            info = soup.select("#delivery-wr > div > div.waybill-tbl > table > tbody > tr:nth-child(%d)" % i)
-            if not info:
-                info = soup.select("#delivery-wr > div > div.waybill-tbl > table > tbody > tr:nth-child(%d)" % int(i-1))
-                for tag in info:
-                    temp += tag.get_text()
-                break
-            i = i+1
-
+        info = soup.select("#delivery-wr > div > div.waybill-tbl > table > tbody > tr")
+        if info:
+            temp = info[-1].get_text()
+        
         infom = temp.split("\n")
-        for _ in range(len(infom)):
-            if infom[7] == "":
-                infom[7] = "(정보 없음)"
-        goods_name = soup.select("#delivery-wr > div > table > tbody > tr > td:nth-child(1)")
-        goods_name = goods_name[0].get_text().strip()
+        
+        if len(infom) > 7 and not infom[7]:
+            infom[7] = "(정보 없음)"
+
+        goods_name = soup.select_one("#delivery-wr > div > table > tbody > tr > td:nth-child(1)")
+        goods_name = goods_name.get_text().strip() if goods_name else ""
+
         return f"/// 한진택배 배송조회 ///\n\n상품명: {goods_name}\n날짜: {infom[1]}\n시간: {infom[2]}\n상품위치: {infom[3]}\n배송 진행상황: {infom[5]}\n전화번호: {infom[7]}"
-    except (TypeError, IndexError):
+
+    except (TypeError, IndexError, AttributeError):
         return None
 
 def message_logistics_parser_koreapost(message) -> str | None:

--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -220,22 +220,27 @@ def message_logistics_parser_logen(message) -> str | None:
         return None
 
 def message_logistics_parser_lotte(message) -> str | None:
-    temp = ""
     try:
-        if not message.isdigit():
-            raise TypeError
         logistics_url = logistics_urls["Lotte"] % (message)
         request_session = requests.Session()
-        request_response = request_session.get(logistics_url, headers = request_headers, verify=certifi.where())
+        request_response = request_session.get(logistics_url, headers=request_headers, verify=certifi.where())
         soup = BeautifulSoup(request_response.text, "html.parser")
+
         info = soup.find("div", "scroll_date_table")
-        for tag in info:
-            temp += tag.get_text()
-        infom = temp.split("\n")
-        for _ in range(len(infom)):
-            infom[_] = infom[_].replace("\t", "").replace("\r", "").replace(" ", "").replace(u"\xa0", "")
+        if not info:
+            return None
+            
+        temp = info.get_text()
+        remove_chars = str.maketrans("", "", "\t\r \xa0")
+        infom = [line.translate(remove_chars) for line in temp.split("\n")]
         infom = [v for v in infom if v]
+        
+        if len(infom) < 9:
+            return None
+
         infom[6] = infom[6][:10] + " " + infom[6][10:]
+        
         return f"/// 롯데택배 배송조회 ///\n\n단계: {infom[5]}\n시간: {infom[6]}\n현위치: {infom[7]}\n처리현황: {infom[8]}"
-    except (TypeError, IndexError):
+
+    except (TypeError, ValueError, IndexError, AttributeError):
         return None

--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -10,6 +10,23 @@ import requests
 
 dotenv.load_dotenv()
 
+request_headers = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/71.0.3578.98 Safari/537.36",
+    "Content-Type": "application/x-www-form-urlencoded"
+}
+
+logistics_urls = {
+    "Customs": "https://unipass.customs.go.kr:38010/ext/rest/cargCsclPrgsInfoQry/retrieveCargCsclPrgsInfo?crkyCn=%s&blYy=%s&hblNo=%s", # 통관
+    "CJ": "https://trace.cjlogistics.com/next/rest/selectTrackingWaybil.do",                                                           # 대한통운 기본 운송장 정보 조회
+    "CJ_status": "https://trace.cjlogistics.com/next/rest/selectTrackingDetailList.do",                                                # 대한통운 배송 정보 상세 조회                       
+    "Hanjin": "https://www.hanjin.com/kor/CMS/DeliveryMgr/WaybillResult.do?mCode=MN038&wblnum=%s&schLang=KR",                          # 한진택배
+    "KoreaPost": "https://service.epost.go.kr/trace.RetrieveDomRigiTraceList.comm?sid1=%s",                                            # 우체국택배
+    "Logen": "https://www.ilogen.com/web/personal/trace/%s",                                                                           # 로젠택배
+    "Lotte": "https://www.lotteglogis.com/mobile/reservation/tracking/linkView?InvNo=%s"                                               # 롯데택배
+}
+
 def message_logistics(message, room, sender):
     if message.startswith("!택배") or message.startswith("!ㅌㅂ"):
         return message_logistics_main(message)
@@ -22,7 +39,7 @@ def message_custom_tracker(message):
         message = message.replace("!통관", "").replace("!ㅌㄱ", "").replace(" ", "")
         key = os.environ["CUSTOM_API_KEY"]
         year = datetime.date.today().year
-        url = "https://unipass.customs.go.kr:38010/ext/rest/cargCsclPrgsInfoQry/retrieveCargCsclPrgsInfo?crkyCn=%s&blYy=%s&hblNo=%s" % (key, year, message)
+        url = logistics_urls["Customs"] % (key, year, message)
         result = requests.get(url)
         soup = BeautifulSoup(result.text, "xml")
         name = soup.find("prnm")
@@ -68,15 +85,9 @@ def message_logistics_parser(message):
 
 def message_logistics_parser_cj(message):
     try:
-        request_headers = {
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
-                          "AppleWebKit/537.36 (KHTML, like Gecko) "
-                          "Chrome/71.0.3578.98 Safari/537.36",
-            "Content-Type": "application/x-www-form-urlencoded"
-        }
         post_data = {"wblNo": message}
-        str_url_info = "https://trace.cjlogistics.com/next/rest/selectTrackingWaybil.do"
-        request_response = requests.post(str_url_info, headers=request_headers, data=post_data)
+        logistics_url_info = logistics_urls["CJ"]
+        request_response = requests.post(logistics_url_info, headers=request_headers, data=post_data)
         if request_response.status_code != 200 or not request_response.json().get("data"): return ""
         tracking_data = request_response.json()["data"]
         sndr_nm = (tracking_data.get("sndrNm") or "").strip() or "(정보 없음)"
@@ -85,8 +96,8 @@ def message_logistics_parser_cj(message):
         qty = (tracking_data.get("qty") or "").strip() or "(정보 없음)"
         acpr_nm = (tracking_data.get("acprNm") or "").strip() or "(정보 없음)"
         
-        str_url_status = "https://trace.cjlogistics.com/next/rest/selectTrackingDetailList.do"
-        request_response = requests.post(str_url_status, headers=request_headers, data=post_data)
+        logistics_url_status = logistics_urls["CJ_status"]
+        request_response = requests.post(logistics_url_status, headers=request_headers, data=post_data)
         status_info = "현재 집하되지 않은 택배입니다."
         if (request_response.status_code == 200 and
             request_response.json().get("data") and
@@ -118,14 +129,9 @@ def message_logistics_parser_hanjin(message):
     temp = ""
     try:
         if not message.isdigit(): raise TypeError
-        request_headers = {
-            "User-Agent" : ("Mozilla/5.0 (Windows NT 10.0;Win64; x64)\
-            AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98\
-            Safari/537.36")
-        }
-        str_url = "https://www.hanjin.com/kor/CMS/DeliveryMgr/WaybillResult.do?mCode=MN038&wblnum=" + message + "&schLang=KR"
+        logistics_url = logistics_urls["Hanjin"] % (message)
         request_session = requests.Session()
-        request_response = request_session.get(str_url, headers = request_headers, verify=certifi.where())
+        request_response = request_session.get(logistics_url, headers = request_headers, verify=certifi.where())
         soup = BeautifulSoup(request_response.text, "html.parser")
         while True:
             info = soup.select("#delivery-wr > div > div.waybill-tbl > table > tbody > tr:nth-child(%d)" % i)
@@ -150,13 +156,9 @@ def message_logistics_parser_koreapost(message):
     temp = ""
     try:
         if not message.isdigit(): raise TypeError
-        request_headers = {
-        "User-Agent" : ("Mozilla/5.0 (Windows NT 10.0;Win64; x64)\
-        AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98\
-        Safari/537.36"), }
-        str_url = "https://service.epost.go.kr/trace.RetrieveDomRigiTraceList.comm?sid1=" + message
+        logistics_url = logistics_urls["KoreaPost"] % (message)
         request_session = requests.Session()
-        request_response = request_session.get(str_url, headers = request_headers, verify=certifi.where())
+        request_response = request_session.get(logistics_url, headers = request_headers, verify=certifi.where())
         soup = BeautifulSoup(request_response.text, "html.parser")
         while True:
             info = soup.select("#processTable > tbody > tr:nth-child(%d)" % i)
@@ -181,13 +183,9 @@ def message_logistics_parser_logen(message):
     try:
         if not message.isdigit():
             raise TypeError
-        request_headers = {
-        "User-Agent" : ("Mozilla/5.0 (Windows NT 10.0;Win64; x64)\
-        AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98\
-        Safari/537.36"), }
-        str_url = "https://www.ilogen.com/web/personal/trace/" + message
+        logistics_url =  logistics_urls["Logen"] % (message)
         request_session = requests.Session()
-        request_response = request_session.get(str_url, headers = request_headers, verify=certifi.where())
+        request_response = request_session.get(logistics_url, headers = request_headers, verify=certifi.where())
         soup = BeautifulSoup(request_response.text, "html.parser")
         while True:
             info = soup.select("body > div.contents.personal.tkSearch > section > div > div.tab_container > div > table.data.tkInfo > tbody > tr:nth-child(%d)" % i)
@@ -215,13 +213,9 @@ def message_logistics_parser_lotte(message):
     try:
         if not message.isdigit():
             raise TypeError
-        request_headers = {
-        "User-Agent" : ("Mozilla/5.0 (Windows NT 10.0;Win64; x64)\
-        AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98\
-        Safari/537.36"), }
-        str_url = "https://www.lotteglogis.com/mobile/reservation/tracking/linkView?InvNo=" + message
+        logistics_url = logistics_urls["Lotte"] % (message)
         request_session = requests.Session()
-        request_response = request_session.get(str_url, headers = request_headers, verify=certifi.where())
+        request_response = request_session.get(logistics_url, headers = request_headers, verify=certifi.where())
         soup = BeautifulSoup(request_response.text, "html.parser")
         info = soup.find("div", "scroll_date_table")
         for tag in info:

--- a/message_util/message_logistics.py
+++ b/message_util/message_logistics.py
@@ -34,7 +34,7 @@ def message_logistics(message, room, sender):
         return message_custom_tracker(message)
     return None
 
-def message_custom_tracker(message):
+def message_custom_tracker(message) -> str:
     try:
         message = message.replace("!통관", "").replace("!ㅌㄱ", "").replace(" ", "")
         key = os.environ["CUSTOM_API_KEY"]
@@ -50,7 +50,7 @@ def message_custom_tracker(message):
     except (TypeError, AttributeError):
         return "존재하지 않는 운송장번호이거나 잘못된 형식 혹은 아직 입항하지 않은 화물입니다.\\m사용법: !통관 123456789"
 
-def message_logistics_main(message):
+def message_logistics_main(message) -> str:
     message = message.replace("!택배", "").replace("!ㅌㅂ", "").replace(" ", "")
 
     if message == "":
@@ -58,12 +58,12 @@ def message_logistics_main(message):
 
     str_message = message_logistics_parser(message)
 
-    if "존재하지 않는 운송장" in str_message:
-        str_message = "현재 택배사에 인계되지 않은 화물입니다."
+    if not str_message:
+        return "존재하지 않는 운송장번호이거나 잘못된 형식 혹은 아직 수거되지 않은 화물입니다.\\m사용법: !택배[운송장번호]\nex)!택배1234567890\n지원중인 택배사: 우체국택배, 대한통운(CJ, 대통), 로젠택배, 롯데택배, 한진택배"
 
     return str_message
 
-def message_logistics_parser(message):
+def message_logistics_parser(message) -> str | None:
     logistics = [message_logistics_parser_cj,
                 message_logistics_parser_hanjin,
                 message_logistics_parser_koreapost,
@@ -74,9 +74,7 @@ def message_logistics_parser(message):
         str_message = parser(message)
         if str_message: return str_message
 
-    str_message = "미집하된 택배이거나 존재하지 않는 운송장 번호입니다.\\m사용 예시: !택배[운송장번호]\nex)!택배1234567890\n지원중인 택배사: 우체국택배, 대한통운(CJ, 대통), 로젠택배, 롯데택배, 한진택배"
-
-    return str_message
+    return None
 
 def message_logistics_parser_cj(message):
     try:


### PR DESCRIPTION
## Summary
- 택배/통관 기능에서 발생하던 오류를 exception하고, 기능을 개선했습니다.

## Description
- 택배를 조회할 때 통관 정보가 있는 경우, 통관 정보를 먼저 보내고 그 이후에 택배 정보를 보내던 구조를 개편했습니다.
  - 이제 통관은 무조건 **!통관** 혹은 **!ㅌㄱ** 키워드를 사용해야만 조회할 수 있습니다.
- 대부분의 함수가 공통으로 사용하던 request_headers를 재사용이 가능하게 파일 상단으로 위치를 이전했습니다.
- 택배/통관 조회 시 사용하던 URL을 파일 상단에 별도의 dict로 빼내어 이후 유지보수에 용이하게 개선했습니다.
- 몇몇 함수에서 중복으로 사용하던 isdigit 검증 로직을 message_logistics_main 함수로 이전했습니다.
- 파싱 함수에 추후 추적이 용이하게끔 주석을 추가했습니다.
- 택배 조회 과정에서 오류가 발생 시 3회까지 재시도를 진행하고, 3회 모두 실패한 경우 오류 로그를 남기는 기능을 추가했습니다.
  - 사용자에게 택배 파싱에 실패했다는 안내는 5개의 택배사에서 모두 배송 조회에 실패한 상태에서, 1회라도 오류가 발생한 경우에만 발송합니다.
- 함수에 return 타입을 추가하고, 내부에서 오류가 발생한 경우 None을 return하게끔 구조를 개편했습니다.
- 데이터를 파싱할 때, 불필요하게 while문을 돌리던 방식에서 데이터를 한번에 파싱하고 가장 마지막 데이터를 사용하는 방식으로 함수를 리펙토링 했습니다.